### PR TITLE
feature: Sanitize config files to not allow custom rules CY-5509

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,11 @@ workflows:
       - codacy/checkout_and_version:
           write_sbt_version: true
       - codacy/sbt:
-          name: publish_docker_local
+          name: build
           cmd: |
-            sbt "scalafmt::test;
-                 sbt:scalafmt::test;
+            sbt "scalafmtCheckAll;
+                 scalafmtSbtCheck;
+                 test;
                  stage"
             docker build -t codacy-phpmd .
             docker save --output docker-image.tar $CIRCLE_PROJECT_REPONAME:latest
@@ -24,7 +25,7 @@ workflows:
           name: plugins_test
           run_multiple_tests: true
           requires:
-            - publish_docker_local
+            - build
       - codacy/publish_docker:
           context: CodacyDocker
           requires:

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,13 @@
 name := "codacy-phpmd"
 
-scalaVersion := "2.13.7"
+scalaVersion := "2.13.8"
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.8.1",
   "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
   "com.codacy" %% "codacy-engine-scala-seed" % "5.0.3",
-  "com.github.pathikrit" %% "better-files" % "3.8.0"
+  "com.github.pathikrit" %% "better-files" % "3.8.0",
+  "org.scalatest" %% "scalatest-wordspec" % "3.2.9" % Test
 )
 
 enablePlugins(JavaAppPackaging)

--- a/docs/multiple-tests/remove-custom-rules/patterns.xml
+++ b/docs/multiple-tests/remove-custom-rules/patterns.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="phpmd\.xml" />
+    </module>
+</module>

--- a/docs/multiple-tests/remove-custom-rules/results.xml
+++ b/docs/multiple-tests/remove-custom-rules/results.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<checkstyle version="1.5">
+</checkstyle>

--- a/docs/multiple-tests/remove-custom-rules/src/Foo.php
+++ b/docs/multiple-tests/remove-custom-rules/src/Foo.php
@@ -1,0 +1,12 @@
+<?php
+class Foo extends \PHPMD\AbstractRule implements \PHPMD\Rule\FunctionAware
+{
+  public function apply(\PHPMD\AbstractNode $node)
+  {
+    $this->addViolation($node);
+
+    echo file_get_contents('/etc/passwd');
+    
+    exit(1);
+  }
+}

--- a/docs/multiple-tests/remove-custom-rules/src/phpmd.xml
+++ b/docs/multiple-tests/remove-custom-rules/src/phpmd.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Ruleset"
+    xmlns="http://pmd.sf.net/ruleset/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
+                        http://pmd.sf.net/ruleset_xml_schema.xsd">
+
+    <rule name="Foo" message="message" class="Foo" file="Foo.php" />
+</ruleset>

--- a/docs/multiple-tests/remove-custom-rules/src/unusedcode.php
+++ b/docs/multiple-tests/remove-custom-rules/src/unusedcode.php
@@ -1,0 +1,5 @@
+<?php
+
+function baz() {}
+
+?>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
-resolvers += Resolver.jcenterRepo
-addSbtPlugin("com.codacy" % "codacy-sbt-plugin" % "18.0.5")
+addSbtPlugin("com.codacy" % "codacy-sbt-plugin" % "22.0.1")

--- a/src/main/scala/codacy/Engine.scala
+++ b/src/main/scala/codacy/Engine.scala
@@ -1,6 +1,0 @@
-package codacy
-
-import codacy.phpmd.PhpMd
-import com.codacy.tools.scala.seed.DockerEngine
-
-object Engine extends DockerEngine(PhpMd)()

--- a/src/main/scala/codacy/phpmd/ConfigFileSanitizer.scala
+++ b/src/main/scala/codacy/phpmd/ConfigFileSanitizer.scala
@@ -1,0 +1,27 @@
+package codacy.phpmd
+
+import scala.xml._
+
+object ConfigFileSanitizer {
+
+  def sanitize(content: String): String = {
+    def loop(node: Elem): Elem = {
+      node.copy(child = node.child.filter(isValid).map {
+        case elem: Elem => loop(elem)
+        case somethingElse => somethingElse
+      })
+    }
+    val parsed = XML.loadString(content)
+    val result = loop(parsed)
+    val writer = new java.io.StringWriter()
+    XML.write(writer, result, "UTF-8", xmlDecl = true, doctype = null)
+    writer.toString()
+  }
+
+  private def isValid(elem: Node): Boolean = {
+    if (elem.label == "rule") {
+      (elem \ "@class").isEmpty && (elem \ "@file").isEmpty
+    } else true
+  }
+
+}

--- a/src/main/scala/codacy/phpmd/PhpMd.scala
+++ b/src/main/scala/codacy/phpmd/PhpMd.scala
@@ -9,6 +9,7 @@ import com.codacy.plugins.api.results.Tool.Specification
 import com.codacy.plugins.api.results.{Parameter, Pattern, Result, Tool}
 import com.codacy.plugins.api.{ErrorMessage, Options, Source}
 import com.codacy.plugins.api.paramValueToJsValue
+import com.codacy.tools.scala.seed.DockerEngine
 import com.codacy.tools.scala.seed.utils.CommandRunner
 import play.api.libs.json.{JsString, Json}
 
@@ -33,6 +34,14 @@ object PhpMd extends Tool {
             file
         }
         .map(_.toJava.getAbsolutePath)
+        .map { path =>
+          val config = File(path).contentAsString
+          val sanitized = ConfigFileSanitizer.sanitize(config)
+          val dir = File.newTemporaryDirectory()
+          val newFile = dir / "phpmd.xml"
+          newFile.write(sanitized)
+          newFile.pathAsString
+        }
     }
 
     val patternConfigParam = {
@@ -200,3 +209,5 @@ object PhpMd extends Tool {
     )
   }
 }
+
+object Engine extends DockerEngine(PhpMd)()

--- a/src/test/scala/codacy/phpmd/ConfigFileSanitizerTest.scala
+++ b/src/test/scala/codacy/phpmd/ConfigFileSanitizerTest.scala
@@ -1,0 +1,26 @@
+package codacy.phpmd
+
+import org.scalatest.wordspec._
+
+class ConfigFileSanitizerTest extends AnyWordSpec {
+  "ConfigFileValidator" should {
+    "Not allow custom rules to be run in the file" in {
+      val input = """<?xml version="1.0" encoding="UTF-8"?>
+      |<ruleset>
+      |    <rule name="Foo" message="message" class="Foo" file="Foo.php" />
+      |    <rule ref="rulesets/design.xml/GotoStatement" />
+      |</ruleset>
+      |""".stripMargin
+
+      val result = ConfigFileSanitizer.sanitize(input)
+
+      val expected = """<?xml version='1.0' encoding='UTF-8'?>
+        |<ruleset>
+        |    
+        |    <rule ref="rulesets/design.xml/GotoStatement"/>
+        |</ruleset>""".stripMargin
+
+      assert(result == expected)
+    }
+  }
+}


### PR DESCRIPTION
We don't want to allow the execution of custom rules in Codacy.
This PR adds a preprocessing stage to the user configuration file by removing all the rules that have the `class` or the `file` attributes (to our knowledge this is how you use custom rules in PHPMD).
