### PR TITLE
bump: Base image to alpine 3.17.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
-  codacy: codacy/base@6.1.1
-  codacy_plugins_test: codacy/plugins-test@0.15.4
+  codacy: codacy/base@9.3.5
+  codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,22 @@
-FROM alpine:3.14.2 as base
+FROM alpine:3.17.0 as base
 
-RUN apk add --no-cache php8 bash php8-simplexml php8-dom php8-tokenizer openjdk8-jre && \
-    ln -s /usr/bin/php8 /usr/bin/php
+RUN apk add --no-cache php bash php-simplexml php-dom php-tokenizer openjdk8-jre
+
 
 FROM base as builder
 
 WORKDIR /workdir
-
 COPY composer.* ./
+RUN apk --no-cache add php-phar php-iconv php-openssl php-xml composer && composer install --no-scripts
 
-# HACK: Make iconv work on Alpine + PHP8
-# https://github.com/docker-library/php/issues/240#issuecomment-762763705
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ gnu-libiconv=1.15-r3 && \
-    apk --no-cache add php8-phar php8-iconv php8-openssl php8-xml && \
-    wget -O /usr/bin/composer https://getcomposer.org/download/2.1.9/composer.phar && \
-    chmod +x /usr/bin/composer && \
-    composer install --no-scripts
 
 FROM base
 
 WORKDIR /workdir
-
 COPY docs /docs
 COPY target/universal/stage/ .
 COPY --from=builder /workdir/vendor vendor
-RUN chmod +x bin/codacy-phpmd && \
-    adduser --uid 2004 --disabled-password --gecos "" docker
+
+RUN chmod +x bin/codacy-phpmd && adduser --uid 2004 --disabled-password --gecos "" docker
 USER docker
 ENTRYPOINT ["bin/codacy-phpmd"]


### PR DESCRIPTION
Bumping orb version to remove vulnerabilities. Using alpine 3.17.0 then php8.1 is the default, and there seems to be no issue with iconv, which allows to simplify the dockerfile. Also bumping orb versions to avoid issues in ci/cd pipelines.